### PR TITLE
Allow Scanner to work outside a Bundler environment

### DIFF
--- a/lib/govuk_security_audit/scanner.rb
+++ b/lib/govuk_security_audit/scanner.rb
@@ -12,6 +12,10 @@ module GovukSecurityAudit
 
       @root = File.dirname(path)
       @database = Bundler::Audit::Database.new
+
+      # Stop Bundler trying to find a Gemfile to accompany our Lockfiles
+      ENV["BUNDLE_GEMFILE"] = "Dummy"
+
       @lockfile = Bundler::LockfileParser.new(File.read(path))
     end
   end


### PR DESCRIPTION
When a LockfileParser is initialised, Bundler will try to find the
related Gemfile in the current directory’s hierarchy. If the tool is
run from a directory that doesn't have a Gemfile in its hierarchy,
Bundler will raise an exception and make the tool fail.

As we don’t need to do anything with the Gemfile in this tool, we tell
Bundler the location of a (dummy) Gemfile explicitly so it doesn’t go
looking.
