### PR TITLE
Fix double-update for Github repos.

### DIFF
--- a/lib/govuk_security_audit/cli.rb
+++ b/lib/govuk_security_audit/cli.rb
@@ -11,7 +11,6 @@ module GovukSecurityAudit
 
     desc "github USER REPO [REF]", "check the Github repo USER/REPO at an optional REF. Defaults to master."
     def github(user, repo, ref="master")
-      update unless options[:skip_update]
       uri = URI.parse("https://raw.githubusercontent.com/#{user}/#{repo}/#{ref}/Gemfile.lock")
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true


### PR DESCRIPTION
Fix a double-call to the update function. The `github` command eventually calls `check`, so no need to explicitly update in the `github` command.
