### PR TITLE
Provides possibility to ignore vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ Check a specific branch on Github:
 ```
 govuk_security_audit github alphagov whitehall upgrade-rails
 ```
+
+Checks but ignores specific vulnerabilities
+
+```
+govuk_security_audit check ~/govuk/whitehall --ignore OSVDB-131677 advisory
+```

--- a/lib/govuk_security_audit/cli.rb
+++ b/lib/govuk_security_audit/cli.rb
@@ -8,6 +8,7 @@ require "govuk_security_audit/scanner"
 module GovukSecurityAudit
   class CLI < Thor
     class_option :skip_update, type: :boolean, default: false
+    class_option :ignore, type: :array, default: []
 
     desc "github USER REPO [REF]", "check the Github repo USER/REPO at an optional REF. Defaults to master."
     def github(user, repo, ref="master")
@@ -30,12 +31,12 @@ module GovukSecurityAudit
     end
 
     desc "check [PATH]", "check the Gemfile at PATH, or the current directory."
-    def check(path=Dir.pwd)
+    def check(path = Dir.pwd)
       update unless options[:skip_update]
       scanner    = Scanner.new(path)
       vulnerable = false
 
-      scanner.scan do |result|
+      scanner.scan(:ignore => options[:ignore]) do |result|
         vulnerable = true
 
         case result

--- a/lib/govuk_security_audit/scanner.rb
+++ b/lib/govuk_security_audit/scanner.rb
@@ -4,8 +4,9 @@ require "bundler/lockfile_parser"
 
 module GovukSecurityAudit
   class Scanner < Bundler::Audit::Scanner
-    def initialize(path=Dir.pwd)
+    def initialize(path = Dir.pwd)
       path = File.expand_path(path)
+
       if File.directory?(path)
         path = File.join(path, "Gemfile.lock")
       end


### PR DESCRIPTION
There are moments when it's not possible to update a given gem straight
away, and sometimes it's ok to ignore because the project doesn't use
that dependency.

And since we are using this in a continuos integration cycle we want it
to not fail unnecessarily every time.

Part of: https://trello.com/c/J8jN7OFV/502-ensure-all-apps-have-up-to-date-dependencies
