### PR TITLE
Update bundler-audit to version 0.5.0

### DIFF
--- a/govuk_security_audit.gemspec
+++ b/govuk_security_audit.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "gem_publisher", "1.5.0"
-  spec.add_dependency "bundler-audit", "~> 0.4.0"
+  spec.add_dependency "bundler-audit", "~> 0.5.0"
   spec.add_dependency "thor", "~> 0.19"
 end


### PR DESCRIPTION
This new release https://github.com/rubysec/bundler-audit/issues/137
Fixes https://github.com/rubysec/bundler-audit/issues/95
And avoids confusion when there's a need of ignoring a certain security
issue.
